### PR TITLE
Add noun counting functionality to review analyzer

### DIFF
--- a/lesson1/app.js
+++ b/lesson1/app.js
@@ -4,8 +4,10 @@ let apiToken = '';
 
 // DOM elements
 const analyzeBtn = document.getElementById('analyze-btn');
+const countNounsBtn = document.getElementById('count-nouns-btn');
 const reviewText = document.getElementById('review-text');
 const sentimentResult = document.getElementById('sentiment-result');
+const nounResult = document.getElementById('noun-result');
 const loadingElement = document.querySelector('.loading');
 const errorElement = document.getElementById('error-message');
 const apiTokenInput = document.getElementById('api-token');
@@ -17,6 +19,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Set up event listeners
     analyzeBtn.addEventListener('click', analyzeRandomReview);
+    countNounsBtn.addEventListener('click', countNounsInReview);
     apiTokenInput.addEventListener('change', saveApiToken);
     
     // Load saved API token if exists
@@ -85,6 +88,8 @@ function analyzeRandomReview() {
     analyzeBtn.disabled = true;
     sentimentResult.innerHTML = '';  // Reset previous result
     sentimentResult.className = 'sentiment-result';  // Reset classes
+    nounResult.className = 'sentiment-result glass-card';
+    nounResult.innerHTML = '<i class="fas fa-language icon"></i><span>Noun statistics will appear here</span>';
     
     // Call Hugging Face API
     analyzeSentiment(selectedReview)
@@ -96,6 +101,29 @@ function analyzeRandomReview() {
         .finally(() => {
             loadingElement.style.display = 'none';
             analyzeBtn.disabled = false;
+        });
+}
+
+function countNounsInReview() {
+    hideError();
+    const text = reviewText.textContent.trim();
+    if (!text || text === 'Click the button above to analyze a random review') {
+        showError('Select a review before counting nouns.');
+        return;
+    }
+    nounResult.className = 'sentiment-result glass-card';
+    nounResult.innerHTML = '<i class="fas fa-spinner fa-spin icon"></i><span>Counting nouns...</span>';
+    countNounsBtn.disabled = true;
+    analyzeNouns(text)
+        .then(nouns => displayNounStats(nouns))
+        .catch(error => {
+            console.error('Error:', error);
+            showError('Failed to count nouns: ' + error.message);
+            nounResult.className = 'sentiment-result glass-card';
+            nounResult.innerHTML = '<i class="fas fa-language icon"></i><span>Noun statistics unavailable</span>';
+        })
+        .finally(() => {
+            countNounsBtn.disabled = false;
         });
 }
 
@@ -119,6 +147,57 @@ async function analyzeSentiment(text) {
     
     const result = await response.json();
     return result;
+}
+
+async function analyzeNouns(text) {
+    const response = await fetch(
+        'https://api-inference.huggingface.co/models/vblagoje/bert-english-uncased-finetuned-pos',
+        {
+            headers: {
+                Authorization: apiToken ? `Bearer ${apiToken}` : undefined,
+                'Content-Type': 'application/json'
+            },
+            method: 'POST',
+            body: JSON.stringify({ inputs: text })
+        }
+    );
+    if (!response.ok) {
+        throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    const items = Array.isArray(data) ? data.flat(Infinity) : [];
+    const nouns = [];
+    items.forEach(item => {
+        const label = (item.entity_group || item.entity || '').toUpperCase();
+        if ((label.includes('NOUN') || label.includes('PROPN')) && Number.isInteger(item.start) && Number.isInteger(item.end)) {
+            const word = text.slice(item.start, item.end).trim();
+            if (word) {
+                nouns.push(word);
+            }
+        }
+    });
+    return nouns;
+}
+
+function displayNounStats(nouns) {
+    nounResult.className = 'sentiment-result glass-card';
+    if (!Array.isArray(nouns) || nouns.length === 0) {
+        nounResult.innerHTML = '<i class="fas fa-language icon"></i><span>No nouns detected</span>';
+        return;
+    }
+    const counts = new Map();
+    nouns.forEach(word => {
+        const key = word.toLowerCase();
+        const entry = counts.get(key) || { word, count: 0 };
+        entry.count += 1;
+        if (entry.count === 1) {
+            entry.word = word;
+        }
+        counts.set(key, entry);
+    });
+    const summary = Array.from(counts.values()).sort((a, b) => b.count - a.count || a.word.localeCompare(b.word));
+    const list = summary.slice(0, 10).map(item => `${item.word} (${item.count})`).join(', ');
+    nounResult.innerHTML = `<i class="fas fa-language icon"></i><div><div><strong>${nouns.length}</strong> nouns, <strong>${summary.length}</strong> unique</div>${list ? `<div>${list}</div>` : ''}</div>`;
 }
 
 // Display sentiment result

--- a/lesson1/index.html
+++ b/lesson1/index.html
@@ -431,6 +431,7 @@
 
         <div class="review-section">
             <button id="analyze-btn"><i class="fas fa-wand-magic-sparkles"></i> Analyze Random Review</button>
+            <button id="count-nouns-btn"><i class="fas fa-book"></i> Count Nouns</button>
             <a id="connect-manager" class="cta-link" href="https://t.me/profit2040" target="_blank" rel="noopener noreferrer">
                 <i class="fa-brands fa-telegram"></i> Connect Manager
             </a>
@@ -450,6 +451,10 @@
             <div class="sentiment-result glass-card" id="sentiment-result">
                 <i class="fas fa-question-circle icon"></i>
                 <span>Sentiment will appear here</span>
+            </div>
+            <div class="sentiment-result glass-card" id="noun-result">
+                <i class="fas fa-language icon"></i>
+                <span>Noun statistics will appear here</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a noun counting control and result panel to the review analyzer interface
- integrate Hugging Face POS tagging to compute noun counts and present validation details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf66bd8748333bf250e8605807a5f