### PR TITLE
Add noun counting workflow

### DIFF
--- a/lesson1/app.js
+++ b/lesson1/app.js
@@ -4,21 +4,27 @@ let apiToken = '';
 
 // DOM elements
 const analyzeBtn = document.getElementById('analyze-btn');
+const countNounsBtn = document.getElementById('count-nouns-btn');
 const reviewText = document.getElementById('review-text');
 const sentimentResult = document.getElementById('sentiment-result');
+const nounResult = document.getElementById('noun-result');
 const loadingElement = document.querySelector('.loading');
 const errorElement = document.getElementById('error-message');
 const apiTokenInput = document.getElementById('api-token');
+const defaultReviewMessage = reviewText.textContent;
+const defaultNounMessage = nounResult.querySelector('span').textContent;
 
 // Initialize the app
 document.addEventListener('DOMContentLoaded', function() {
     // Load the TSV file (Papa Parse 활성화)
     loadReviews();
-    
+
     // Set up event listeners
     analyzeBtn.addEventListener('click', analyzeRandomReview);
+    countNounsBtn.addEventListener('click', countNouns);
     apiTokenInput.addEventListener('change', saveApiToken);
-    
+    countNounsBtn.disabled = true;
+
     // Load saved API token if exists
     const savedToken = localStorage.getItem('hfApiToken');
     if (savedToken) {
@@ -69,17 +75,19 @@ function saveApiToken() {
 // Analyze a random review
 function analyzeRandomReview() {
     hideError();
-    
+
     if (reviews.length === 0) {
         showError('No reviews available. Please try again later.');
         return;
     }
     
     const selectedReview = reviews[Math.floor(Math.random() * reviews.length)];
-    
+
     // Display the review
     reviewText.textContent = selectedReview;
-    
+    updateNounResult('fa-language', defaultNounMessage);
+    countNounsBtn.disabled = false;
+
     // Show loading state
     loadingElement.style.display = 'block';
     analyzeBtn.disabled = true;
@@ -101,23 +109,10 @@ function analyzeRandomReview() {
 
 // Call Hugging Face API for sentiment analysis
 async function analyzeSentiment(text) {
-    const response = await fetch(
+    const result = await postModel(
         'https://api-inference.huggingface.co/models/siebert/sentiment-roberta-large-english',
-        {
-            headers: { 
-                Authorization: apiToken ? `Bearer ${apiToken}` : undefined,
-                'Content-Type': 'application/json'
-            },
-            method: 'POST',
-            body: JSON.stringify({ inputs: text }),
-        }
+        { inputs: text }
     );
-    
-    if (!response.ok) {
-        throw new Error(`API error: ${response.status} ${response.statusText}`);
-    }
-    
-    const result = await response.json();
     return result;
 }
 
@@ -171,4 +166,111 @@ function showError(message) {
 // Hide error message
 function hideError() {
     errorElement.style.display = 'none';
+}
+
+async function countNouns() {
+    hideError();
+    const text = reviewText.textContent.trim();
+    if (!text || text === defaultReviewMessage) {
+        showError('Please analyze a review before counting nouns.');
+        return;
+    }
+    countNounsBtn.disabled = true;
+    updateNounResult('fa-spinner', 'Counting nouns...', true);
+    try {
+        const tokens = await analyzePos(text);
+        const summary = summarizeNouns(tokens, text);
+        if (summary.total === 0) {
+            updateNounResult('fa-language', 'No nouns detected');
+        } else {
+            const details = summary.breakdown
+                .slice(0, 5)
+                .map(item => `${item.word} (${item.count})`)
+                .join(', ');
+            const extra = summary.breakdown.length > 5 ? `, +${summary.breakdown.length - 5} more` : '';
+            updateNounResult('fa-language', `${summary.total} nouns detected • ${details}${extra}`);
+        }
+    } catch (error) {
+        console.error('Error:', error);
+        showError('Failed to count nouns: ' + error.message);
+        updateNounResult('fa-language', defaultNounMessage);
+    } finally {
+        countNounsBtn.disabled = false;
+    }
+}
+
+async function analyzePos(text) {
+    const result = await postModel(
+        'https://api-inference.huggingface.co/models/vblagoje/bert-english-uncased-finetuned-pos',
+        { inputs: text }
+    );
+    if (!Array.isArray(result)) {
+        throw new Error('Unexpected API response');
+    }
+    return result;
+}
+
+async function postModel(url, payload) {
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiToken) {
+        headers.Authorization = `Bearer ${apiToken}`;
+    }
+    const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+        throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+}
+
+function summarizeNouns(tokens, text) {
+    const nounTags = new Set(['NOUN', 'PROPN']);
+    const counts = new Map();
+    let total = 0;
+    tokens.forEach(token => {
+        const group = token.entity_group || token.entity || token.tag;
+        if (!group || !nounTags.has(group.toUpperCase())) {
+            return;
+        }
+        const surface = extractSurface(text, token);
+        if (!surface) {
+            return;
+        }
+        total += 1;
+        const key = surface.toLowerCase();
+        if (counts.has(key)) {
+            counts.get(key).count += 1;
+        } else {
+            counts.set(key, { word: surface, count: 1 });
+        }
+    });
+    return { total, breakdown: Array.from(counts.values()).sort((a, b) => b.count - a.count || a.word.localeCompare(b.word)) };
+}
+
+function extractSurface(text, token) {
+    if (typeof token.start === 'number' && typeof token.end === 'number') {
+        const value = text.slice(token.start, token.end).trim();
+        if (value) {
+            return value;
+        }
+    }
+    if (token.word) {
+        return token.word.replace(/^##/, '').replace(/^Ġ/, '').trim();
+    }
+    return '';
+}
+
+function updateNounResult(iconClass, message, spinning) {
+    nounResult.innerHTML = '';
+    const icon = document.createElement('i');
+    icon.className = `fas ${iconClass} icon`;
+    if (spinning) {
+        icon.classList.add('fa-spin');
+    }
+    const span = document.createElement('span');
+    span.textContent = message;
+    nounResult.append(icon, span);
 }

--- a/lesson1/index.html
+++ b/lesson1/index.html
@@ -247,6 +247,7 @@
         }
 
         #analyze-btn,
+        #count-nouns-btn,
         #connect-manager {
             align-self: center;
         }
@@ -431,6 +432,7 @@
 
         <div class="review-section">
             <button id="analyze-btn"><i class="fas fa-wand-magic-sparkles"></i> Analyze Random Review</button>
+            <button id="count-nouns-btn"><i class="fas fa-language"></i> Count Nouns</button>
             <a id="connect-manager" class="cta-link" href="https://t.me/profit2040" target="_blank" rel="noopener noreferrer">
                 <i class="fa-brands fa-telegram"></i> Connect Manager
             </a>
@@ -450,6 +452,11 @@
             <div class="sentiment-result glass-card" id="sentiment-result">
                 <i class="fas fa-question-circle icon"></i>
                 <span>Sentiment will appear here</span>
+            </div>
+
+            <div class="sentiment-result glass-card" id="noun-result">
+                <i class="fas fa-language icon"></i>
+                <span>Noun count will appear here</span>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a noun counting control to the review analyzer interface
- integrate Hugging Face POS tagging to count and summarize nouns for validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db0091898883338c4f89a09d348113